### PR TITLE
Fix Atom v1.13.+ deprecations

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,5 +1,5 @@
 @import 'syntax-variables';
-:host, .atom-text-editor {
+atom-text-editor, .atom-text-editor {
 	background-color: @syntax-background-color;
 	color: @syntax-text-color;
 
@@ -36,42 +36,42 @@
 		background-color: @syntax-selection-color;
 	}
 	// Markdown Styles
-	.source.gfm {
+	.syntax--source.syntax--gfm {
 		color: #999;
 	}
-	.gfm {
-		.markup.heading {
+	.syntax--gfm {
+		.syntax--markup.syntax--heading {
 			color: #eee;
 		}
-		.link {
+		.syntax--link {
 			color: #555;
 		}
-		.variable.list,
-		.support.quote {
+		.syntax--variable.syntax--list,
+		.syntax--support.syntax--quote {
 			color: #555;
 		}
-		.link .entity {
+		.syntax--link .syntax--entity {
 			color: #ddd;
 		}
-		.raw {
+		.syntax--raw {
 			color: #aaa;
 		}
 	}
-	.markdown {
-		.paragraph {
+	.syntax--markdown {
+		.syntax--paragraph {
 			color: #999;
 		}
-		.heading {
+		.syntax--heading {
 			color: #eee;
 		}
-		.raw {
+		.syntax--raw {
 			color: #aaa;
 		}
-		.link {
+		.syntax--link {
 			color: #555;
-			.string {
+			.syntax--string {
 				color: #555;
-				&.title {
+				&.syntax--title {
 					color: #ddd;
 				}
 			}
@@ -83,146 +83,146 @@
 	margin-top: -1px;
 	opacity: 0.7;
 }
-.comment {
+.syntax--comment {
 	color: #bc9458;
 	font-style: italic;
 }
-.keyword {
+.syntax--keyword {
 	color: #cc7833;
-	&.control {
+	&.syntax--control {
 		color: #cc7833;
 	}
-	&.operator {
+	&.syntax--operator {
 		color: #cc7833;
 	}
 }
-.storage {
+.syntax--storage {
 	color: #cfcb90;
-	&.class,
-	&.function,
-	&.modifier {
+	&.syntax--class,
+	&.syntax--function,
+	&.syntax--modifier {
 		color: #cc7833;
 	}
 }
-.constant {
+.syntax--constant {
 	color: #a5c261;
-	&.numeric {
+	&.syntax--numeric {
 		color: #a5c261;
 	}
-	&.boolean {
+	&.syntax--boolean {
 		color: #6d9cbe;
 	}
 }
-.variable {
+.syntax--variable {
 	color: #d0d0ff;
-	&.assignment {
+	&.syntax--assignment {
 		color: @syntax-text-color;
 	}
 }
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
 	text-decoration: underline;
 	color: #fd5ff1;
 }
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
 	color: #fd5ff1;
 	background-color: rgba(86, 45, 86, 0.75);
 }
 // String interpolation in Ruby, CoffeeScript, and others
-.source .string {
-	.source,
-	.meta.embedded.line {
+.syntax--source .syntax--string {
+	.syntax--source,
+	.syntax--meta.syntax--embedded.line {
 		color: #ededed;
 	}
-	.punctuation.section.embedded {
+	.syntax--punctuation.syntax--section.syntax--embedded {
 		color: #00a0a0;
-		.source {
+		.syntax--source {
 			color: #00a0a0;
 			// Required for the end of embedded strings in Ruby #716
 		}
 	}
 }
-.string {
+.syntax--string {
 	color: #a5c261;
-	.constant {
+	.syntax--constant {
 		color: #a5c261;
 	}
-	&.regexp {
+	&.syntax--regexp {
 		color: #e9c062;
-		.constant.character.escape,
-		.source.ruby.embedded,
-		.string.regexp.arbitrary-repetition {
+		.syntax--constant.syntax--character.syntax--escape,
+		.syntax--source.syntax--ruby.syntax--embedded,
+		.syntax--string.syntax--regexp.syntax--arbitrary-repetition {
 			color: #519f50;
 		}
-		&.group {
+		&.syntax--group {
 			color: #c6a24f;
 			background-color: rgba(255, 255, 255, 0.06);
 		}
-		&.character-class {
+		&.syntax--character-class {
 			color: #b18a3d;
 		}
 	}
 }
-.support {
-	&.function {
+.syntax--support {
+	&.syntax--function {
 		color: #da4939;
 	}
-	&.constant {
-		&.w3c-standard-color-name {
+	&.syntax--constant {
+		&.syntax--w3c-standard-color-name {
 			color: #6d9cbe;
 		}
 	}
-	&.type.property-name.css {
+	&.syntax--type.syntax--property-name.syntax--css {
 		color: #6d9cbe;
 	}
 }
-.entity {
+.syntax--entity {
 	color: #ffc66d;
-	&.type.class,
-	&.inherited-class {
+	&.syntax--type.syntax--class,
+	&.syntax--inherited-class {
 		color: @syntax-text-color;
 	}
 }
-.tag {
+.syntax--tag {
 	color: #ffc66d;
 }
-.meta {
-	&.preprocessor.c {
+.syntax--meta {
+	&.syntax--preprocessor.syntax--c {
 		color: #8996a8;
 	}
-	&.preprocessor.c .keyword {
+	&.syntax--preprocessor.syntax--c .syntax--keyword {
 		color: #afc4db;
 	}
-	&.cast {
+	&.syntax--cast {
 		color: #676767;
 	}
-	&.sgml.html .meta.doctype,
-	&.sgml.html .meta.doctype .entity,
-	&.sgml.html .meta.doctype .string,
+	&.syntax--sgml.syntax--html .syntax--meta.syntax--doctype,
+	&.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--entity,
+	&.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--string,
 	&.xml-processing,
-	&.xml-processing .entity,
-	&.xml-processing .string {
+	&.xml-processing .syntax--entity,
+	&.xml-processing .syntax--string {
 		color: #494949;
 	}
-	&.preprocessor.at-rule .keyword.control.at-rule {
+	&.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
 		color: #8693a5;
 	}
-	&.constructor.argument.css {
+	&.syntax--constructor.syntax--argument.syntax--css {
 		color: #8f9d6a;
 	}
-	&.diff,
-	&.diff.header {
+	&.syntax--diff,
+	&.syntax--diff.syntax--header {
 		color: #f8f8f8;
 		background-color: #0e2231;
 	}
-	&.separator {
+	&.syntax--separator {
 		color: #60a633;
 		background-color: #242424;
 	}
-	&.line.entry.logfile,
-	&.line.exit.logfile {
+	&.line.syntax--entry.logfile,
+	&.line.syntax--exit.logfile {
 		background-color: rgba(238, 238, 238, 0.16);
 	}
-	&.line.error.logfile {
+	&.line.syntax--error.logfile {
 		background-color: #751012;
 	}
 }


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--.